### PR TITLE
Improve order_by performance

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -32,3 +32,9 @@ Layout/LineLength:
 
 Naming/VariableNumber:
   EnforcedStyle: snake_case
+
+# In Ruby 3.0 interpolated strings will no longer be frozen automatically, so
+# to ensure consistent performance, we have to manually call `String#freeze` in
+# some places.
+Style/RedundantFreeze:
+  Enabled: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ These are the latest changes on the project's `master` branch that have not yet 
 ### Changed
 - **Breaking change:** The way records are retrieved from a given cursor has been changed to no longer use `CONCAT` but instead simply use a compound `WHERE` clause in case of a custom order and having both the custom field as well as the `id` field in the `ORDER BY` query. This is a breaking change since it now changes the internal order of how records with the same value of the `order_by` field are returned.
 - Remove `ORDER BY` clause from `COUNT` queries
+         
+### Fixed
+- Only trigger one SQL query to load the records from the database and use it to determine if there was a previous / is a next page
 
 ## [0.1.3] - 2021-03-17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,9 @@ These are the latest changes on the project's `master` branch that have not yet 
 ### Fixed
 - Only trigger one SQL query to load the records from the database and use it to determine if there was a previous / is a next page
 
+### Added
+- Description about `order_by` on arbitrary SQL to README.md
+
 ## [0.1.3] - 2021-03-17
 
 ### Changed
@@ -28,7 +31,7 @@ These are the latest changes on the project's `master` branch that have not yet 
 - Reference changelog file in the gemspec instead of the general releases Github tab
 
 ### Removed
-- Remove bulk from release: The previous gem releases contained files like the content of the `bin` folder or the Gemfile used for testing. Since this is not useful for gem users, adjust the gemspec file accordingly. 
+- Remove bulk from release: The previous gem releases contained files like the content of the `bin` folder or the Gemfile used for testing. Since this is not useful for gem users, adjust the gemspec file accordingly.
 
 ## [0.1.2] - 2021-02-04
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ These are the latest changes on the project's `master` branch that have not yet 
 
 ### Changed
 - **Breaking change:** The way records are retrieved from a given cursor has been changed to no longer use `CONCAT` but instead simply use a compound `WHERE` clause in case of a custom order and having both the custom field as well as the `id` field in the `ORDER BY` query. This is a breaking change since it now changes the internal order of how records with the same value of the `order_by` field are returned.
+- Remove `ORDER BY` clause from `COUNT` queries
 
 ## [0.1.3] - 2021-03-17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ These are the latest changes on the project's `master` branch that have not yet 
   Follow the same format as previous releases by categorizing your feature into "Added", "Changed", "Deprecated", "Removed", "Fixed", or "Security".
 --->
 
+### Changed
+- **Breaking change:** The way records are retrieved from a given cursor has been changed to no longer use `CONCAT` but instead simply use a compound `WHERE` clause in case of a custom order and having both the custom field as well as the `id` field in the `ORDER BY` query. This is a breaking change since it now changes the internal order of how records with the same value of the `order_by` field are returned.
+
 ## [0.1.3] - 2021-03-17
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ These are the latest changes on the project's `master` branch that have not yet 
          
 ### Fixed
 - Only trigger one SQL query to load the records from the database and use it to determine if there was a previous / is a next page
+- Memoize the `Paginator#page` method which is invoked multiple times to prevent it from mapping over the `records` again and again and rebuilding all cursors
 
 ### Added
 - Description about `order_by` on arbitrary SQL to README.md

--- a/README.md
+++ b/README.md
@@ -178,6 +178,29 @@ end
 ```
 
 Please take a look at the _"How does it work?"_ to find out more why this is necessary.
+          
+#### Order by more complex logic
+
+Sometimes you might not only want to oder by a column ascending or descending, but need more complex logic.
+Imagine you would also store the post's `category` on the `posts` table (as a plain string for simplicity's sake).
+And the category could be `pinned`, `announcement`, or `general`.
+Then you might want to show all `pinned` posts first, followed by the `announcement` ones and lastly show the `general` posts.
+
+In MySQL you could e.g. use a `FIELD(category, 'pinned', 'announcement', 'general')` query in the `ORDER BY` clause to achieve this.
+However, you cannot add an index to such a statement.
+And therefore, the performance of this is – especially when using cursor pagination where we not only have an `ORDER BY` clause but also need it twice in the `WHERE` clauses – is pretty dismal.
+
+For this reason, the gem currently only supports ordering by natural columns of the relation.
+You **cannot** pass a generic SQL query to the `order_by` parameter.
+
+Implementing support for arbitrary SQL queries would also be fairly complex to handle in this gem.
+We would have to ensure that SQL injection attacks aren't possible by passing malicious code to the `oder_by` parameter.
+And we would need to return the data produced by the statement so that it can be encoded in the cursor.
+This is, for now, out of scope of the functionality of this gem.
+
+What is recommended if you _do_ need to order by more complex logic is to have a separate column that you only use for ordering.
+You can use `ActiveRecord` hooks to automatically update this column whenever you change your data.
+Or, for example in MySQL, you can also use a [generated column](https://dev.mysql.com/doc/refman/5.7/en/create-table-generated-columns.html) that is automatically being updated by the database based on some stored logic. 
 
 ### Configuration options
 

--- a/lib/rails_cursor_pagination.rb
+++ b/lib/rails_cursor_pagination.rb
@@ -96,11 +96,11 @@
 #
 #     SELECT *
 #     FROM "posts"
-#     ORDER BY CONCAT(author, '-', "posts"."id") ASC
+#     ORDER BY "posts"."author" ASC, "posts"."id" ASC
 #     LIMIT 2
 #
-# As you can see, this will now order by a concatenation of the requested
-# column, a dash `-`, and the ID column. Ordering only the author is not
+# As you can see, this will now order by the author first, and if two records
+# have the same author it will order them by ID. Ordering only the author is not
 # enough since we cannot know if the custom column only has unique values.
 # And we need to guarantee the correct order of ambiguous records independent
 # of the direction of ordering. This unique order is the basis of being able
@@ -128,18 +128,22 @@
 #
 #     SELECT *
 #     FROM "posts"
-#     WHERE CONCAT(author, '-', "posts"."id") > 'Jane-4'
-#     ORDER BY CONCAT(author, '-', "posts"."id") ASC
+#     WHERE (author > 'Jane' OR (author = 'Jane') AND ("posts"."id" > 4))
+#     ORDER BY "posts"."author" ASC, "posts"."id" ASC
 #     LIMIT 2
 #
-# You can see how the cursor is being translated into the WHERE clause to
-# uniquely identify the row and properly filter based on this. We will get
-# the records #5 and #2 as response.
+# You can see how the cursor is being used by the WHERE clause to uniquely
+# identify the row and properly filter based on this. We only want to get
+# records that either have a name that is alphabetically after `"Jane"` or
+# another `"Jane"` record with an ID that is higher than `4`. We will get the
+# records #5 and #2 as response.
 #
-# As you can see, when using a custom `order_by`, the concatenation is used
-# for both filtering and ordering. Therefore, it is recommended to add an
-# index for columns that are frequently used for ordering. In our test case
-# we would want to add an index for `CONCAT(author, '-', id)`.
+# When using a custom `order_by`, this affects both filtering as well as
+# ordering. Therefore, it is recommended to add an index for columns that are
+# frequently used for ordering. In our test case we would want to add a compound
+# index for the `(author, id)` column combination. Databases like MySQL and
+# Postgres are able to then use the leftmost part of the index, in our case
+# `author`, by its own _or_ can use it combined with the `id` index.
 #
 module RailsCursorPagination
   class Error < StandardError; end

--- a/lib/rails_cursor_pagination/paginator.rb
+++ b/lib/rails_cursor_pagination/paginator.rb
@@ -147,11 +147,13 @@ module RailsCursorPagination
     #
     # @return [Array<Hash>] List of hashes, each with a `cursor` and `data`
     def page
-      records.map do |item|
-        {
-          cursor: cursor_for_record(item),
-          data: item
-        }
+      memoize :page do
+        records.map do |item|
+          {
+            cursor: cursor_for_record(item),
+            data: item
+          }
+        end
       end
     end
 

--- a/lib/rails_cursor_pagination/paginator.rb
+++ b/lib/rails_cursor_pagination/paginator.rb
@@ -159,7 +159,7 @@ module RailsCursorPagination
     #
     # @return [Integer]
     def total
-      memoize(:total) { @relation.size }
+      memoize(:total) { @relation.reorder('').size }
     end
 
     # Check if the pagination direction is forward
@@ -186,11 +186,12 @@ module RailsCursorPagination
         # When paginating forward, we can only have a previous page if we were
         # provided with a cursor and there were records discarded after applying
         # this filter. These records would have to be on previous pages.
-        @cursor.present? && filtered_and_sorted_relation.size < total
+        @cursor.present? &&
+          filtered_and_sorted_relation.reorder('').size < total
       else
         # When paginating backwards, if we managed to load one more record than
         # requested, this record will be available on the previous page.
-        @page_size < limited_relation_plus_one.size
+        @page_size < limited_relation_plus_one.reorder('').size
       end
     end
 
@@ -201,12 +202,12 @@ module RailsCursorPagination
       if paginate_forward?
         # When paginating forward, if we managed to load one more record than
         # requested, this record will be available on the next page.
-        @page_size < limited_relation_plus_one.size
+        @page_size < limited_relation_plus_one.reorder('').size
       else
         # When paginating backward, if applying our cursor reduced the number
         # records returned, we know that the missing records will be on
         # subsequent pages.
-        filtered_and_sorted_relation.size < total
+        filtered_and_sorted_relation.reorder('').size < total
       end
     end
 

--- a/spec/rails_cursor_pagination/paginator_spec.rb
+++ b/spec/rails_cursor_pagination/paginator_spec.rb
@@ -162,25 +162,25 @@ RSpec.describe RailsCursorPagination::Paginator do
       ]
     end
     let(:posts_by_author) do
-      # Note that the ID is being used in a string sorting. Therefore, the order
-      # is '1' < '10' < '2' (instead of 1 < 2 < 10 as it would be for integers).
+      # Posts are first ordered by the author's name and then, in case of two
+      # posts having the same author, by ID
       [
         # All posts by "Jane"
-        post_13,
         post_2,
         post_3,
         post_5,
         post_7,
-        post_10,
+        post_13,
         # All posts by "Jess"
         post_9,
-        post_1,
+        post_10,
         # All posts by "John"
-        post_11,
-        post_12,
+        post_1,
         post_4,
         post_6,
-        post_8
+        post_8,
+        post_11,
+        post_12
       ]
     end
 


### PR DESCRIPTION
As raised in [issue #3](https://github.com/xing/rails_cursor_pagination/issues/3) by @domangi, the performance of the previous implementation when passing an `order_by` parameter was pretty bad. It suggested users should set an index onto `CONCAT(<order_by_column>, '-', id)` – but it turns out that neither MySQL nor Postgres support indices on a function like that.

The solution that was suggested in the issue was to remove custom ordering for non-unique columns from the gem all together and leave it up to the user to ensure that a column is unique. But in my opinion this would make the barrier of entry for this gem quite high as most columns on normal relations are not unique by default, so users would have to manually add and maintain a unique column for each of the columns they'd want to sort on.

This PR suggests an improved mechanism to make the old behavior work. It also brings some other performance improvements and the sorting now happens based on the actual column type. It does _not_ add support for arbitrary SQL queries in the `order_by` param, but adds some description to the `README.md` file around this.

The new mechanism works like this (as also detailed in #3):

If this gem gets called like this:
```ruby
RailsCursorPagination::Paginator
  .new(relation, order_by: :author, first: 2, after: "WyJKYW5lIiw0XQ==")
  .fetch
```

and our cursor encodes something like `['Jane', 4]`, the generated SQL query so far was
```sql
SELECT *
FROM "posts"
WHERE CONCAT(author, '-', "posts"."id") > 'Jane-4'
ORDER BY CONCAT(author, '-', "posts"."id") ASC
LIMIT 2
```
which was performing poorly since contrary to this gem's documentation neither MySQL nor Postgres support indices on functions like `CONCAT`.

But we can rewrite this query to something like this:
```sql
SELECT *
FROM "posts"
WHERE (author > 'Jane') OR (author = 'Jane' AND "posts"."id" > 4)
ORDER BY author ASC, "posts"."id" ASC
LIMIT 2
```

If we then add a compound index to `(author, id)`, the database can use this to resolve both the `WHERE` clauses as well as the `ORDER BY` condition. I created an index on MySQL like this:
```sql
CREATE INDEX index_posts_on_author_and_id ON posts (author, id);
```

And then an `EXPLAIN` on the `SELECT` query returned this (on a database with 10000 records):
```
+----+-------------+-------+------------+-------+--------------------------------------+------------------------------+---------+------+------+----------+-----------------------+
| id | select_type | table | partitions | type  | possible_keys                        | key                          | key_len | ref  | rows | filtered | Extra                 |
+----+-------------+-------+------------+-------+--------------------------------------+------------------------------+---------+------+------+----------+-----------------------+
|  1 | SIMPLE      | posts | NULL       | range | PRIMARY,index_posts_on_author_and_id | index_posts_on_author_and_id | 776     | NULL | 5016 |   100.00 | Using index condition |
+----+-------------+-------+------------+-------+--------------------------------------+------------------------------+---------+------+------+----------+-----------------------+
```

So it managed to use the index for a `range` query. 

_**In detail:**_

**Change queries used for pagination when `order_by` parameter is passed**

The previous logic relied on using concatenation to generate a unique field that could both be filtered and sorted over. This was done with
the assumption that databases would allow adding an index on such a concatenated field. But this is actually not the case, neither MySQL nor Postgres support indices on functions like `CONCAT`.

Therefore, the queries used by the gem had a vert poor performance.

To combat this, the queries are now changed to query the given `order_by` field and the ID field separately and also have them separately in the `ORDER BY` clause. This allows making use of a compound or multicolumn index on the combination of the two fields.

Since both MySQL and Postgres support efficient use of compound indices when accessing / filtering over / ordering by either all fields of the index or the leftmost fields only, and index on `(<custom_column>, id)` will ensure a high performance of these queries.

Furthermore, abandoning the concatenation now also ensures that non-string columns are ordered as expected. Before, e.g. integer columns were treated as text columns, leading to weird orders like `1, 10, 11, 2, 3, 4`. This has also been solved with these changes.

However, due to this changing the order of the returned results, releasing this cause a breaking change.


**Remove `ORDER BY` clause from `COUNT` queries**

Since we just used the pre-assembled relations to then call `#size` on them, this caused queries like this to be sent to the database:
```
SELECT COUNT(*) FROM (
  SELECT 1 AS one
  FROM `posts`
  ORDER BY `posts`.`author` DESC, `posts`.`id` DESC
  LIMIT 3
) subquery_for_count
```

The `ORDER BY` part will never influence the number of returned records. But depending on the used database and their query optimization settings, it will make the query less performant.

Therefore, remove any order from the queries before calling `#size` on them. With `ActiveRecord` this can be achieved by calling `#reorder` on the relation with an empty string.


**Ensure records are fetched early to avoid multiple DB queries**

One of the optimizations that cursor pagination allows is fetching one more record than required from the database to then be able to efficiently determine if there is another page (which would contain at the least this extra item). However, the way this was implemented it actually triggered individual queries, one to load the records and another `COUNT` query to determine the amount of records with the additional one. This was due to how ActiveRecord tries to delay fetching records of a relation to the latest possible point.

To prevent this, we can call `#fetch` manually to request the records to be loaded earlier.


**Add explanation to README.md about ordering by arbitrary SQL**

The gem in its current version does not allow ordering by any arbitrary SQL statements. Only SQL columns can be used.

This is on one side due to performance reasons, but on the other side also due to the added high complexity of supporting arbitrary SQL queries. We would have to ensure that it doesn't open the door for SQL injection attacks. We would also have to return the value of this query so that it can be properly encoded into the cursor.

For now, this is out of scope for this gem.


**Memoize the `Paginator#page` method**

This method is invoked multiple times to retrieve the `start_cursor`, the `end_cursor`, and ultimately to return the actual `page` record. By memoizing it, we avoid it from mapping over the `records` again and again and rebuilding all the cursors every time it is invoked.

Resolves #3