### PR TITLE
Disable CI on Postgres version <= 11 fix change setup

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,11 +46,11 @@ jobs:
           DB_USER: root
 
   test-on-postgres:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
         ruby-version: ['2.6', '2.7', '3.0']
-        postgres-version: [13, 12, 11, 10, 9.6]
+        postgres-version: [13, 12]
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
Since around April 15th the tests on Postgres started failing due to having issues will running `sudo apt-get install postgresql-<version>`. This is done internally by the `ankane/setup-postgres` step and up to that point worked without issues. Up to that date we used Ubuntu 18.04 but there, no Postgres version could be installed via the script anymore. While investigating, we found that on Ubuntu 20.04 Postgres 12 and 13 could at least still be installed.

This was unrelated to any changes done in this repository. Therefore, to unblock further development of this gem, upgrade the PG tests to use Ubuntu 20.04 and remove the PG versions that no longer seem to work from the test matrix.

Also, create #9 to re-enable tests for older Postgres versions to ensure compatibility of the gem.