### PR TITLE
Add decorator functionality

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -3,7 +3,7 @@ AllCops:
   NewCops: enable
 
 Metrics/AbcSize:
-  Max: 25
+  Max: 30
 
 # DSLs inheritly uses long blocks, like describe and contexts in RSpec,
 # therefore disable this rule for specs and for the gemspec file
@@ -13,22 +13,22 @@ Metrics/BlockLength:
   - spec/**/*
 
 Metrics/ClassLength:
-  Max: 200
+  Max: 205
 
 Metrics/CyclomaticComplexity:
   Max: 15
 
 Metrics/MethodLength:
-  Max: 25
+  Max: 30
 
 Metrics/ParameterLists:
-  Max: 7
+  Max: 8
 
 Metrics/PerceivedComplexity:
-  Max: 13
+  Max: 14
 
 Layout/LineLength:
-  Max: 80
+  Max: 95
 
 Naming/VariableNumber:
   EnforcedStyle: snake_case

--- a/lib/rails_cursor_pagination/paginator.rb
+++ b/lib/rails_cursor_pagination/paginator.rb
@@ -399,9 +399,7 @@ module RailsCursorPagination
 
       relation = @relation
 
-      unless @relation.select_values.include?(:id)
-        relation = relation.select(:id)
-      end
+      relation = relation.select(:id) unless @relation.select_values.include?(:id)
 
       if custom_order_field? && !@relation.select_values.include?(@order_field)
         relation = relation.select(@order_field)

--- a/lib/rails_cursor_pagination/paginator.rb
+++ b/lib/rails_cursor_pagination/paginator.rb
@@ -50,7 +50,8 @@ module RailsCursorPagination
       order_by ||= :id
       order ||= :asc
 
-      ensure_valid_params!(relation, first, after, last, before, order, record_decorator)
+      ensure_valid_params!(relation, first, after, last, before, order,
+                           record_decorator)
 
       @order_field = order_by
       @order_direction = order

--- a/lib/rails_cursor_pagination/paginator.rb
+++ b/lib/rails_cursor_pagination/paginator.rb
@@ -46,11 +46,11 @@ module RailsCursorPagination
     # @raise [RailsCursorPagination::Paginator::ParameterError]
     #   If any parameter is not valid
     def initialize(relation, first: nil, after: nil, last: nil, before: nil,
-                   order_by: nil, order: nil, decorator: :itself.to_proc)
+                   order_by: nil, order: nil, record_decorator: :itself.to_proc)
       order_by ||= :id
       order ||= :asc
 
-      ensure_valid_params!(relation, first, after, last, before, order, decorator)
+      ensure_valid_params!(relation, first, after, last, before, order, record_decorator)
 
       @order_field = order_by
       @order_direction = order
@@ -64,7 +64,7 @@ module RailsCursorPagination
         last ||
         RailsCursorPagination::Configuration.instance.default_page_size
 
-      @decorator = decorator
+      @record_decorator = record_decorator
 
       @memos = {}
     end
@@ -104,7 +104,7 @@ module RailsCursorPagination
     #
     # @raise [RailsCursorPagination::Paginator::ParameterError]
     #   If any parameter is not valid
-    def ensure_valid_params!(relation, first, after, last, before, order, decorator)
+    def ensure_valid_params!(relation, first, after, last, before, order, record_decorator)
       unless relation.is_a?(ActiveRecord::Relation)
         raise ParameterError,
               'The first argument must be an ActiveRecord::Relation, but was '\
@@ -129,8 +129,8 @@ module RailsCursorPagination
       if last.present? && last.negative?
         raise ParameterError, "`last` cannot be negative, but was `#{last}`"
       end
-      unless decorator.respond_to?(:call)
-        raise ParameterError, '`decorator` must respond to .call'
+      unless record_decorator.respond_to?(:call)
+        raise ParameterError, '`record_decorator` must respond to .call'
       end
 
       true
@@ -156,7 +156,7 @@ module RailsCursorPagination
         records.map do |item|
           {
             cursor: cursor_for_record(item),
-            data: @decorator.call(item)
+            data: @record_decorator.call(item)
           }
         end
       end

--- a/lib/rails_cursor_pagination/paginator.rb
+++ b/lib/rails_cursor_pagination/paginator.rb
@@ -42,6 +42,9 @@ module RailsCursorPagination
     #   ```
     # @param order [Symbol, nil]
     #   Ordering to apply, either `:asc` or `:desc`. Defaults to `:asc`.
+    # @param record_decorator [Object, proc { |obj| obj.itself }]
+    #   Object to which each paginated record will be passed to. Default behavior
+    #   simply returns the record itself. Object must be callable.
     #
     # @raise [RailsCursorPagination::Paginator::ParameterError]
     #   If any parameter is not valid
@@ -102,6 +105,8 @@ module RailsCursorPagination
     #   Optional, cannot be combined with `after`
     # @param order [Symbol]
     #   Optional, must be :asc or :desc
+    # @param record_decorator [Object, proc { |obj| obj.itself }]
+    #   Optional, must respond to `.call`
     #
     # @raise [RailsCursorPagination::Paginator::ParameterError]
     #   If any parameter is not valid
@@ -149,7 +154,8 @@ module RailsCursorPagination
       }
     end
 
-    # Get the records for the given page along with their cursors
+    # Get the records for the given page along with their cursors.
+    # Returned data will have been passed to record_decorator.
     #
     # @return [Array<Hash>] List of hashes, each with a `cursor` and `data`
     def page

--- a/spec/rails_cursor_pagination/paginator_spec.rb
+++ b/spec/rails_cursor_pagination/paginator_spec.rb
@@ -126,7 +126,7 @@ RSpec.describe RailsCursorPagination::Paginator do
       end
 
       context 'passing an invalid `record_decorator`' do
-        let(:params) { super().merge(record_decorator: "no") }
+        let(:params) { super().merge(record_decorator: 'no') }
 
         include_examples 'for a ParameterError with the right message',
                          '`record_decorator` must respond to .call'
@@ -295,7 +295,9 @@ RSpec.describe RailsCursorPagination::Paginator do
         let(:params) { super().merge(record_decorator: id_incrementer) }
 
         it 'returns decorated records' do
-          expect(subject[:page].pluck(:data)).to eq expected_posts.map { |post| id_incrementer.call(post) }
+          expect(subject[:page].pluck(:data)).to eq expected_posts.map { |post|
+                                                      id_incrementer.call(post)
+                                                    }
         end
       end
     end

--- a/spec/rails_cursor_pagination/paginator_spec.rb
+++ b/spec/rails_cursor_pagination/paginator_spec.rb
@@ -124,6 +124,13 @@ RSpec.describe RailsCursorPagination::Paginator do
         include_examples 'for a ParameterError with the right message',
                          '`last` cannot be negative, but was `-4`'
       end
+
+      context 'passing an invalid `decorator`' do
+        let(:params) { super().merge(decorator: "no") }
+
+        include_examples 'for a ParameterError with the right message',
+                         '`decorator` must respond to .call'
+      end
     end
   end
 
@@ -272,6 +279,14 @@ RSpec.describe RailsCursorPagination::Paginator do
         it 'also includes the `total` of records' do
           is_expected.to have_key :total
           expect(subject[:total]).to eq expected_total
+        end
+      end
+
+      context 'when passing a valid lambda as `&decorator`' do
+        let(:params) { { decorator: :class.to_proc } }
+
+        it 'returns decorated records' do
+          expect(subject[:page].pluck(:data)).to all be Post
         end
       end
     end

--- a/spec/rails_cursor_pagination/paginator_spec.rb
+++ b/spec/rails_cursor_pagination/paginator_spec.rb
@@ -289,6 +289,15 @@ RSpec.describe RailsCursorPagination::Paginator do
           expect(subject[:page].pluck(:data)).to all be Post
         end
       end
+
+      context 'when passing a valid lambda as `&record_decorator`' do
+        let(:id_incrementer) { ->(item) { { next_id: item.id + 1 } } }
+        let(:params) { super().merge(record_decorator: id_incrementer) }
+
+        it 'returns decorated records' do
+          expect(subject[:page].pluck(:data)).to eq expected_posts.map { |post| id_incrementer.call(post) }
+        end
+      end
     end
 
     shared_examples_for 'a well working query that also supports SELECT' do

--- a/spec/rails_cursor_pagination/paginator_spec.rb
+++ b/spec/rails_cursor_pagination/paginator_spec.rb
@@ -293,11 +293,14 @@ RSpec.describe RailsCursorPagination::Paginator do
       context 'when passing a valid lambda as `&record_decorator`' do
         let(:id_incrementer) { ->(item) { { next_id: item.id + 1 } } }
         let(:params) { super().merge(record_decorator: id_incrementer) }
+        let(:expected_decorated_response) do
+          expected_posts.map do |post|
+            id_incrementer.call(post)
+          end
+        end
 
         it 'returns decorated records' do
-          expect(subject[:page].pluck(:data)).to eq expected_posts.map { |post|
-                                                      id_incrementer.call(post)
-                                                    }
+          expect(subject[:page].pluck(:data)).to eq expected_decorated_response
         end
       end
     end

--- a/spec/rails_cursor_pagination/paginator_spec.rb
+++ b/spec/rails_cursor_pagination/paginator_spec.rb
@@ -125,11 +125,11 @@ RSpec.describe RailsCursorPagination::Paginator do
                          '`last` cannot be negative, but was `-4`'
       end
 
-      context 'passing an invalid `decorator`' do
-        let(:params) { super().merge(decorator: "no") }
+      context 'passing an invalid `record_decorator`' do
+        let(:params) { super().merge(record_decorator: "no") }
 
         include_examples 'for a ParameterError with the right message',
-                         '`decorator` must respond to .call'
+                         '`record_decorator` must respond to .call'
       end
     end
   end
@@ -282,8 +282,8 @@ RSpec.describe RailsCursorPagination::Paginator do
         end
       end
 
-      context 'when passing a valid lambda as `&decorator`' do
-        let(:params) { { decorator: :class.to_proc } }
+      context 'when passing a valid proc as `&record_decorator`' do
+        let(:params) { { record_decorator: :class.to_proc } }
 
         it 'returns decorated records' do
           expect(subject[:page].pluck(:data)).to all be Post


### PR DESCRIPTION
## Background
The particular use case of presenting/decorating the fetched records is one that is not currently accounted for. I thought it would make good sense to be able to supply some decorator that the `Paginator` could use to change the returned data.

## Changes
- [ ] update readme
- [ ] update change log
- [x] add `decorator` kwarg
- [x] calls `decorator` on each `item` (https://github.com/xing/rails_cursor_pagination/pull/27/files#diff-c201f4d60dd83e98535d880e8d9b9ad479792383bb84e0cddd4a9122514e11b5R159)
- [ ] add contributors