### PR TITLE
Set Ruby 2.7 as minimum version

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,5 @@
 AllCops:
-  TargetRubyVersion: 2.5
+  TargetRubyVersion: 2.7
   NewCops: enable
 
 Metrics/AbcSize:

--- a/rails_cursor_pagination.gemspec
+++ b/rails_cursor_pagination.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
     'of changes to the base relation.'
   spec.homepage = 'https://github.com/xing/rails_cursor_pagination'
   spec.license = 'MIT'
-  spec.required_ruby_version = Gem::Requirement.new('>= 2.5.0')
+  spec.required_ruby_version = Gem::Requirement.new('>= 2.7.0')
 
   spec.metadata['homepage_uri'] = spec.homepage
   spec.metadata['source_code_uri'] = spec.homepage

--- a/spec/rails_cursor_pagination/paginator_spec.rb
+++ b/spec/rails_cursor_pagination/paginator_spec.rb
@@ -492,13 +492,13 @@ RSpec.describe RailsCursorPagination::Paginator do
         context 'when not enough records are remaining after cursor' do
           include_examples 'for a working query' do
             let(:cursor_object_plain) { posts[-2] }
-            let(:expected_posts_plain) { posts[-1..-1] }
+            let(:expected_posts_plain) { posts[-1..] }
 
             let(:cursor_object_desc) { posts[1] }
             let(:expected_posts_desc) { posts[0..0].reverse }
 
             let(:cursor_object_by_author) { posts_by_author[-2] }
-            let(:expected_posts_by_author) { posts_by_author[-1..-1] }
+            let(:expected_posts_by_author) { posts_by_author[-1..] }
 
             let(:cursor_object_by_author_desc) { posts_by_author[1] }
             let(:expected_posts_by_author_desc) do
@@ -558,14 +558,14 @@ RSpec.describe RailsCursorPagination::Paginator do
             let(:expected_posts_plain) { posts[0..0] }
 
             let(:cursor_object_desc) { posts[-2] }
-            let(:expected_posts_desc) { posts[-1..-1].reverse }
+            let(:expected_posts_desc) { posts[-1..].reverse }
 
             let(:cursor_object_by_author) { posts_by_author[1] }
             let(:expected_posts_by_author) { posts_by_author[0..0] }
 
             let(:cursor_object_by_author_desc) { posts_by_author[-2] }
             let(:expected_posts_by_author_desc) do
-              posts_by_author[-1..-1].reverse
+              posts_by_author[-1..].reverse
             end
 
             let(:expected_has_next_page) { true }


### PR DESCRIPTION
Ruby 2.5 and 2.6 arrived to its EOL. This PR sets the minimum version to Ruby 2.7.

Also, changes the target version for Rubocop, fixing the following error that appears after this change:

![Screenshot 2022-06-28 at 09 07 38](https://user-images.githubusercontent.com/6084749/176115910-efc99bc3-7173-4e44-9037-22a10e8edcbe.png)
