### PR TITLE
Internal change: Supports selecting *

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ These are the latest changes on the project's `master` branch that have not yet 
   This will ensure that they're also mentioned in the next release description.
   Follow the same format as previous releases by categorizing your feature into "Added", "Changed", "Deprecated", "Removed", "Fixed", or "Security".
 --->
-
+- Supports explicitly requesting all columns without re-including the requested column
 - Require multi-factor-authentication to publish the gem on Rubygems
 
 ## [0.2.0] - 2021-04-19

--- a/lib/rails_cursor_pagination/paginator.rb
+++ b/lib/rails_cursor_pagination/paginator.rb
@@ -389,7 +389,8 @@ module RailsCursorPagination
     #
     # @return [ActiveRecord::Relation]
     def relation_with_cursor_fields
-      return @relation if @relation.select_values.blank?
+      return @relation if @relation.select_values.blank? ||
+                          @relation.select_values.include?('*')
 
       relation = @relation
 

--- a/spec/rails_cursor_pagination/paginator_spec.rb
+++ b/spec/rails_cursor_pagination/paginator_spec.rb
@@ -277,8 +277,6 @@ RSpec.describe RailsCursorPagination::Paginator do
     end
 
     shared_examples_for 'a well working query that also supports SELECT' do
-      it_behaves_like 'a properly returned response'
-
       context 'when SELECTing all columns' do
         context 'without calling select' do
           it_behaves_like 'a properly returned response'

--- a/spec/rails_cursor_pagination/paginator_spec.rb
+++ b/spec/rails_cursor_pagination/paginator_spec.rb
@@ -279,6 +279,18 @@ RSpec.describe RailsCursorPagination::Paginator do
     shared_examples_for 'a well working query that also supports SELECT' do
       it_behaves_like 'a properly returned response'
 
+      context 'when SELECTing all columns' do
+        context 'without calling select' do
+          it_behaves_like 'a properly returned response'
+        end
+
+        context 'including the "*" select' do
+          let(:selected_attributes) { ['*'] }
+
+          it_behaves_like 'a properly returned response'
+        end
+      end
+
       context 'when SELECTing only some columns' do
         let(:selected_attributes) { %i[id author] }
         let(:relation) { super().select(*selected_attributes) }


### PR DESCRIPTION
Breakup from: https://github.com/xing/rails_cursor_pagination/pull/68

**Support `.select('*')**

The purpose of these changes were us adapting our in-house pagination to this library without having to modify our FE client; as such we had to make three modifications for the following reasons.

**Supporting select.(["*"])**
This one was indirectly needed by us, we are on at least one instance attempting to order by a virtual column that we are sending on the select. (And then selecting all other columns with *)
Ultimately the BEST approach would be to avoid adding the select when the virtual column (using the aliasing AS column_name) is already selecting it; but this feels complex as it requires interpreting the partial SQL on that subquery. At the very least this gives us a way forward.