### PR TITLE
End support for Ruby 2.5 and add Ruby 3.1

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-18.04
     strategy:
       matrix:
-        ruby-version: ['2.6', '2.7', '3.0']
+        ruby-version: ['2.6', '2.7', '3.0', '3.1']
         mysql-version: ['5.7', '8.0']
 
     steps:
@@ -49,7 +49,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        ruby-version: ['2.6', '2.7', '3.0']
+        ruby-version: ['2.6', '2.7', '3.0', '3.1']
         postgres-version: [14, 13, 12]
 
     steps:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,5 @@
 AllCops:
-  TargetRubyVersion: 2.5
+  TargetRubyVersion: 2.6
   NewCops: enable
 
 Metrics/AbcSize:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,9 @@ These are the latest changes on the project's `master` branch that have not yet 
 - Supports explicitly requesting all columns without re-including the requested column
 - Require multi-factor-authentication to publish the gem on Rubygems
 
+### Removed
+- **Breaking change:** Drop support for Ruby 2.5 (EOL 2021-03-31)
+
 ## [0.2.0] - 2021-04-19
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -412,6 +412,20 @@ You can also run `bin/console` for an interactive prompt that will allow you to 
 To install this gem onto your local machine, run `bundle exec rake install`.
 To release a new version, update the version number in `version.rb`, and then run `bundle exec rake release`, which will create a git tag for the version, push git commits and the created tag, and push the `.gem` file to [rubygems.org](https://rubygems.org).
 
+## Supported environments
+
+This gem should run in any project that uses:
+* Ruby
+* `ActiveRecord`
+* Postgres or MySQL
+
+We aim to support all versions that are still actively maintained and extend support until one year past the version's EOL.
+While we think it's important to stay up-to-date with versions and update as soon as an EOL is reached, we know that this is not always immediately possible.
+This way, we hope to strike a balance between being usable by most projects without forcing them to upgrade, but also keeping the supported version combinations manageable.
+
+This project is tested against different permutations of Ruby versions and DB versions, both Postgres and MySQL.
+Please check the [test automation file under `./.github/workflows/test.yml`](.github/workflows/test.yml) to see all officially supported combinations.
+
 ## Contributing
 
 Bug reports and pull requests are welcome on GitHub at https://github.com/xing/rails_cursor_pagination.

--- a/rails_cursor_pagination.gemspec
+++ b/rails_cursor_pagination.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
     'of changes to the base relation.'
   spec.homepage = 'https://github.com/xing/rails_cursor_pagination'
   spec.license = 'MIT'
-  spec.required_ruby_version = Gem::Requirement.new('>= 2.5.0')
+  spec.required_ruby_version = Gem::Requirement.new('>= 2.6.0')
 
   spec.metadata['homepage_uri'] = spec.homepage
   spec.metadata['source_code_uri'] = spec.homepage

--- a/spec/rails_cursor_pagination/paginator_spec.rb
+++ b/spec/rails_cursor_pagination/paginator_spec.rb
@@ -548,13 +548,13 @@ RSpec.describe RailsCursorPagination::Paginator do
         context 'when not enough records are remaining after cursor' do
           include_examples 'for a working query' do
             let(:cursor_object_plain) { posts[-2] }
-            let(:expected_posts_plain) { posts[-1..-1] }
+            let(:expected_posts_plain) { posts[-1..] }
 
             let(:cursor_object_desc) { posts[1] }
             let(:expected_posts_desc) { posts[0..0].reverse }
 
             let(:cursor_object_by_author) { posts_by_author[-2] }
-            let(:expected_posts_by_author) { posts_by_author[-1..-1] }
+            let(:expected_posts_by_author) { posts_by_author[-1..] }
 
             let(:cursor_object_by_author_desc) { posts_by_author[1] }
             let(:expected_posts_by_author_desc) do
@@ -614,14 +614,14 @@ RSpec.describe RailsCursorPagination::Paginator do
             let(:expected_posts_plain) { posts[0..0] }
 
             let(:cursor_object_desc) { posts[-2] }
-            let(:expected_posts_desc) { posts[-1..-1].reverse }
+            let(:expected_posts_desc) { posts[-1..].reverse }
 
             let(:cursor_object_by_author) { posts_by_author[1] }
             let(:expected_posts_by_author) { posts_by_author[0..0] }
 
             let(:cursor_object_by_author_desc) { posts_by_author[-2] }
             let(:expected_posts_by_author_desc) do
-              posts_by_author[-1..-1].reverse
+              posts_by_author[-1..].reverse
             end
 
             let(:expected_has_next_page) { true }


### PR DESCRIPTION
### End support for Ruby 2.5

Also add a section to the `README.md` explaining what versions are supported and fix Rubocop violations that stemmed from the new target version.

### Add Ruby 3.1 to the test matrix

We want to ensure that we remain compatible with the new version.
