### PR TITLE
Remove nesting of error classes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,9 @@ These are the latest changes on the project's `master` branch that have not yet 
 - Supports explicitly requesting all columns without re-including the requested column
 - Require multi-factor-authentication to publish the gem on Rubygems
 
+### Changed
+- **Breaking change:** Remove nesting of `ParameterError` and `InvalidCursorError` errors, they are now directly nested under the main gem module. So they're now `RailsCursorPagination::ParameterError` and `RailsCursorPagination::InvalidCursorError`.
+
 ## [0.2.0] - 2021-04-19
 
 ### Changed

--- a/lib/rails_cursor_pagination.rb
+++ b/lib/rails_cursor_pagination.rb
@@ -148,6 +148,14 @@
 module RailsCursorPagination
   class Error < StandardError; end
 
+  # Generic error that gets raised when invalid parameters are passed to the
+  # pagination
+  class ParameterError < Error; end
+
+  # Error that gets raised if a cursor given as `before` or `after` cannot be
+  # properly parsed
+  class InvalidCursorError < ParameterError; end
+
   require_relative 'rails_cursor_pagination/version'
 
   require_relative 'rails_cursor_pagination/configuration'

--- a/lib/rails_cursor_pagination/cursor.rb
+++ b/lib/rails_cursor_pagination/cursor.rb
@@ -4,11 +4,6 @@ module RailsCursorPagination
   # Cursor class that's used to uniquely identify a record and serialize and
   # deserialize this cursor so that it can be used for pagination.
   class Cursor
-    # Generic error that gets raised when invalid parameters are passed to the
-    # Paginator initializer
-    class ParameterError < Error; end
-    class InvalidCursorError < ParameterError; end
-
     attr_reader :id, :order_field_value
 
     class << self

--- a/lib/rails_cursor_pagination/paginator.rb
+++ b/lib/rails_cursor_pagination/paginator.rb
@@ -11,14 +11,6 @@ module RailsCursorPagination
   #       .fetch
   #
   class Paginator
-    # Generic error that gets raised when invalid parameters are passed to the
-    # Paginator initializer
-    class ParameterError < Error; end
-
-    # Error that gets raised if a cursor given as `before` or `after` parameter
-    # cannot be properly parsed
-    class InvalidCursorError < ParameterError; end
-
     # Create a new instance of the `RailsCursorPagination::Paginator`
     #
     # @param relation [ActiveRecord::Relation]

--- a/spec/rails_cursor_pagination/cursor_spec.rb
+++ b/spec/rails_cursor_pagination/cursor_spec.rb
@@ -115,7 +115,7 @@ RSpec.describe RailsCursorPagination::Cursor do
           message = "The given cursor `#{encoded}` was decoded as " \
                     "`#{record.id}` but could not be parsed"
           expect { decoded }.to raise_error(
-            ::RailsCursorPagination::Cursor::InvalidCursorError,
+            ::RailsCursorPagination::InvalidCursorError,
             message
           )
         end
@@ -138,7 +138,7 @@ RSpec.describe RailsCursorPagination::Cursor do
                     "`[\"#{record.author}\", #{record.id}]` " \
                     'but could not be parsed'
           expect { decoded }.to raise_error(
-            ::RailsCursorPagination::Cursor::InvalidCursorError,
+            ::RailsCursorPagination::InvalidCursorError,
             message
           )
         end
@@ -168,7 +168,7 @@ RSpec.describe RailsCursorPagination::Cursor do
           message = "The given cursor `#{encoded}` " \
                     'could not be decoded'
           expect { decoded }.to raise_error(
-            ::RailsCursorPagination::Cursor::InvalidCursorError,
+            ::RailsCursorPagination::InvalidCursorError,
             message
           )
         end
@@ -183,7 +183,7 @@ RSpec.describe RailsCursorPagination::Cursor do
           message = "The given cursor `#{encoded}` " \
                     'could not be decoded'
           expect { decoded }.to raise_error(
-            ::RailsCursorPagination::Cursor::InvalidCursorError,
+            ::RailsCursorPagination::InvalidCursorError,
             message
           )
         end
@@ -209,7 +209,7 @@ RSpec.describe RailsCursorPagination::Cursor do
             message = 'The `order_field` was set to ' \
                       '`:author` but no `order_field_value` was set'
             expect { cursor }.to raise_error(
-              ::RailsCursorPagination::Cursor::ParameterError,
+              ::RailsCursorPagination::ParameterError,
               message
             )
           end

--- a/spec/rails_cursor_pagination/paginator_spec.rb
+++ b/spec/rails_cursor_pagination/paginator_spec.rb
@@ -68,7 +68,7 @@ RSpec.describe RailsCursorPagination::Paginator do
       shared_examples 'for a ParameterError with the right message' do |message|
         it 'raises an error with the right message' do
           expect { subject }
-            .to raise_error ::RailsCursorPagination::Paginator::ParameterError,
+            .to raise_error ::RailsCursorPagination::ParameterError,
                             message
         end
       end


### PR DESCRIPTION
From the outside, the user is not interested in which nested class an error appeared. The client app only wants to be able to catch meaningful errors to then handle them accordingly.

The recent (and overdue) refactoring of extracting the cursor into its own class in https://github.com/xing/rails_cursor_pagination/pull/74 spread the locations from where errors can occur across two classes. To simplify usage of the gem, this is now consolidated into two error classes mounted right under the main module that should allow for a uniform error handling.

This constitutes a breaking change as error handling code within clients will need to be adjusted.