### PR TITLE
Use UTC when encoding datetime values into cursor.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 These are the latest changes on the project's `master` branch that have not yet been released.
 
+### Fixed
+- Use UTC when encoding datetime values into cursor, therefore playing nicely with rails' default behaviour of storing UTC in the database.
+
 <!---
   If you submit a pull request for this gem, please add a summary of your changes here.
   This will ensure that they're also mentioned in the next release description.
@@ -34,7 +37,7 @@ These are the latest changes on the project's `master` branch that have not yet 
 ### Changed
 - **Breaking change:** The way records are retrieved from a given cursor has been changed to no longer use `CONCAT` but instead simply use a compound `WHERE` clause in case of a custom order and having both the custom field as well as the `id` field in the `ORDER BY` query. This is a breaking change since it now changes the internal order of how records with the same value of the `order_by` field are returned.
 - Remove `ORDER BY` clause from `COUNT` queries
-         
+
 ### Fixed
 - Only trigger one SQL query to load the records from the database and use it to determine if there was a previous / is a next page
 - Memoize the `Paginator#page` method which is invoked multiple times to prevent it from mapping over the `records` again and again and rebuilding all cursors
@@ -56,7 +59,7 @@ These are the latest changes on the project's `master` branch that have not yet 
 ### Fixed
 - Pagination for relations in which a custom `SELECT` does not contain cursor-relevant fields like `:id` or the field specified via `order_by`
 
-## [0.1.1] - 2021-01-21 
+## [0.1.1] - 2021-01-21
 
 ### Added
 - Add support for handling `nil` for `order` and `order_by` values as if they were not passed

--- a/lib/rails_cursor_pagination/cursor.rb
+++ b/lib/rails_cursor_pagination/cursor.rb
@@ -68,7 +68,7 @@ module RailsCursorPagination
     def initialize(id:, order_field: :id, order_field_value: nil)
       @id = id
       @order_field = order_field
-      @order_field_value = order_field_value
+      @order_field_value = normalized_order_field_value(order_field_value)
 
       return if !custom_order_field? || !order_field_value.nil?
 
@@ -103,6 +103,17 @@ module RailsCursorPagination
     # @return [Boolean]
     def custom_order_field?
       @order_field != :id
+    end
+
+    # Returns the value given, but transforms datetime values to UTC if
+    # applicable
+    #
+    # @return [Object]
+    def normalized_order_field_value(value)
+      return value unless ActiveRecord::Base.time_zone_aware_attributes
+      return value unless ActiveRecord::Base.default_timezone == :utc
+
+      value.respond_to?(:utc) ? value.utc : value
     end
   end
 end

--- a/spec/rails_cursor_pagination/paginator_spec.rb
+++ b/spec/rails_cursor_pagination/paginator_spec.rb
@@ -229,7 +229,7 @@ RSpec.describe RailsCursorPagination::Paginator do
           )
         end
       end
-      let(:expected_attributes) { %i[id author content] }
+      let(:expected_attributes) { %i[id author content created_at] }
 
       it 'has the correct format' do
         is_expected.to be_a Hash

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -22,6 +22,10 @@ RSpec.configure do |config|
   ActiveRecord::Base.logger = Logger.new(ENV['VERBOSE'] ? $stdout : nil)
   ActiveRecord::Migration.verbose = ENV.fetch('VERBOSE', nil)
 
+  # Configure time_zone like it would be in rails applications
+  ActiveRecord::Base.time_zone_aware_attributes = true
+  Time.zone = 'Berlin'
+
   ActiveRecord::Base.establish_connection(
     adapter: ENV.fetch('DB_ADAPTER', 'mysql2'),
     database: 'rails_cursor_pagination_testing',
@@ -35,6 +39,7 @@ RSpec.configure do |config|
   ActiveRecord::Migration.create_table :posts do |t|
     t.string :author
     t.string :content
+    t.datetime :created_at
   end
 
   config.before(:each) { Post.delete_all }


### PR DESCRIPTION
Hello,

Rails stores datetime values in the DB as UTC as a default. When using a custom `order_by` on a datetime field, e.g. `updated_at` however, the `order_field_value` is encoded in the local time zone, which leads to faulty pagination.

This PR fixes this issue by always treating the value as UTC if it responds to `utc`. To provide a meaningful test case I've change the spec setup slightly, so that it operates in a different time zone, but still treats datetimes correctly.

To some users, if they were deviating from rails defaults and stored datetimes in local time, this might be a breaking change. However, I'd assume that majority of rails applications adheres to the default.