### PR TITLE
fix: undefined column error when using custom order field

### DIFF
--- a/lib/rails_cursor_pagination/paginator.rb
+++ b/lib/rails_cursor_pagination/paginator.rb
@@ -386,7 +386,7 @@ module RailsCursorPagination
     # @return [ActiveRecord::Relation]
     def relation_with_cursor_fields
       return @relation if @relation.select_values.blank? ||
-                          @relation.select_values.include?('*')
+                          @relation.select_values.any? {|value| value.end_with?('*') }
 
       relation = @relation
 
@@ -394,7 +394,8 @@ module RailsCursorPagination
         relation = relation.select(:id)
       end
 
-      if custom_order_field? && !@relation.select_values.include?(@order_field)
+      if custom_order_field? && 
+         !@relation.select_values.any? {|value| value.end_with?(@order_field)}
         relation = relation.select(@order_field)
       end
 


### PR DESCRIPTION
When providing a relation that selects a virtual field for ordering and does not also select a wildcard, the query will append the order field a second time.

For example:

```ruby
relation = Member.select('members.*', 'random() * 100 as random_order')
RailsCursorPagination::Paginator.new(relation, order_by: :random_order).fetch

#=> "PG::UndefinedColumn: ERROR:  column "random_order" does not exist

# Resulting query:
# "SELECT members.*, random() * 100 as random_order, members.id, random_order FROM members..."
```

This is most likely to happen on a query that relies on a join, as with a `has_many :through` association, where calling `select('*')` on the association is liable to return unpredictable results due to returning multiple ID columns, and so on.

This fixes the issue by not assuming that potential order columns are defined in the DB schema, and by allowing for wildcard select's that are table specific. 

(Although I wonder if it would be easier to not bother with this kind of check when the application can be responsible for providing a 'correct' relation).