### PR TITLE
Allow disabling previous and next page checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ These are the latest changes on the project's `master` branch that have not yet 
   Follow the same format as previous releases by categorizing your feature into "Added", "Changed", "Deprecated", "Removed", "Fixed", or "Security".
 --->
 
+### Added
+- Add option to not include `has_previous_page` and `has_next_page` in the `page_info`
+
 ## [0.3.0] - 2022-07-08
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -77,6 +77,9 @@ If omitted, or set to `false`, the resulting hash will lack the `:total` key, bu
 It is therefore recommended to only pass `with_total: true` when requested by the user.
 So in the next examples we will also leave it away.
 
+By default, the page_info also includes the 'has_previous_page' and 'has_next_page' keys. These are set to true if there's a previous or next page, respectively.
+Both sometimes requires a count query to be executed, which can be expensive. If you want to disable this behavior, you can pass `check_next: false` and/or `check_previous: false`.
+
 To then get the next result page, you simply need to pass the last cursor of the returned page item via:
 
 ```ruby

--- a/lib/rails_cursor_pagination/paginator.rb
+++ b/lib/rails_cursor_pagination/paginator.rb
@@ -74,11 +74,13 @@ module RailsCursorPagination
     # `total` of records across all pages.
     #
     # @param with_total [TrueClass, FalseClass]
+    # @param check_next [TrueClass, FalseClass]
+    # @param check_previous [TrueClass, FalseClass]
     # @return [Hash] with keys :page, :page_info, and optional :total
-    def fetch(with_total: false)
+    def fetch(with_total: false, check_next: true, check_previous: true)
       {
         **(with_total ? { total: total } : {}),
-        page_info: page_info,
+        page_info: page_info(check_next, check_previous),
         page: page
       }
     end
@@ -164,11 +166,13 @@ module RailsCursorPagination
 
     # Get meta information about the current page
     #
+    # @param check_next [TrueClass, FalseClass]
+    # @param check_previous [TrueClass, FalseClass]
     # @return [Hash]
-    def page_info
+    def page_info(check_next, check_previous)
       {
-        has_previous_page: previous_page?,
-        has_next_page: next_page?,
+        **(check_previous ? { has_previous_page: previous_page? } : {}),
+        **(check_next ? { has_next_page: next_page? } : {}),
         start_cursor: start_cursor,
         end_cursor: end_cursor
       }

--- a/spec/rails_cursor_pagination/paginator_spec.rb
+++ b/spec/rails_cursor_pagination/paginator_spec.rb
@@ -295,6 +295,22 @@ RSpec.describe RailsCursorPagination::Paginator do
           expect(subject[:total]).to eq expected_total
         end
       end
+
+      context 'when passing `check_next: false`' do
+        subject(:result) { instance.fetch(check_next: false) }
+
+        it 'does not include the `has_next_page` in `page_info`' do
+          expect(subject[:page_info]).to_not have_key :has_next_page
+        end
+      end
+
+      context 'when passing `check_previous: false`' do
+        subject(:result) { instance.fetch(check_previous: false) }
+
+        it 'does not include the `has_previous_page` in `page_info`' do
+          expect(subject[:page_info]).to_not have_key :has_previous_page
+        end
+      end
     end
 
     shared_examples_for 'a well working query that also supports SELECT' do


### PR DESCRIPTION
The previous_page? and next_page? methods in certain cases require a count query in order to determine if the next/previous pages exists. These count queries can be expensive so an option to disable these checks are added.

For backwards compatibility these checks are enabled by default.