### PR TITLE
Add support for custom primary_key

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -13,7 +13,7 @@ Metrics/BlockLength:
   - spec/**/*
 
 Metrics/ClassLength:
-  Max: 198
+  Max: 228
 
 Metrics/CyclomaticComplexity:
   Max: 15
@@ -22,7 +22,7 @@ Metrics/MethodLength:
   Max: 25
 
 Metrics/ParameterLists:
-  Max: 8
+  Max: 9
 
 Metrics/PerceivedComplexity:
   Max: 13

--- a/lib/rails_cursor_pagination/cursor.rb
+++ b/lib/rails_cursor_pagination/cursor.rb
@@ -6,7 +6,7 @@ module RailsCursorPagination
   # Cursor class that's used to uniquely identify a record and serialize and
   # deserialize this cursor so that it can be used for pagination.
   class Cursor
-    attr_reader :id, :order_field_value
+    attr_reader :primary_key_value, :order_field_value
 
     class << self
       # Generate a cursor for the given record and ordering field. The cursor
@@ -17,10 +17,15 @@ module RailsCursorPagination
       #   Model instance for which we want the cursor
       # @param order_field [Symbol]
       #   Column or virtual column of the record that the relation is ordered by
+      # @param primary_key [Symbol, String]
+      #   Column or virtual column of the record to be used instead of `id` as
+      #   primary key.
       # @return [Cursor]
-      def from_record(record:, order_field: :id)
-        new(id: record.id, order_field: order_field,
-            order_field_value: record[order_field])
+      def from_record(record:, order_field: :id, primary_key: :id)
+        new(primary_key_value: record[primary_key],
+            order_field: order_field,
+            order_field_value: record[order_field],
+            primary_key: primary_key)
       end
 
       # Decode the provided encoded cursor. Returns an instance of this
@@ -34,23 +39,25 @@ module RailsCursorPagination
       #   Optional. The column that is being ordered on in case it's not the ID
       #   column
       # @return [RailsCursorPagination::Cursor]
-      def decode(encoded_string:, order_field: :id)
+      def decode(encoded_string:, order_field: :id, primary_key: :id)
         decoded = JSON.parse(Base64.strict_decode64(encoded_string))
-        if order_field == :id
+        if order_field == primary_key
           if decoded.is_a?(Array)
             raise InvalidCursorError,
                   "The given cursor `#{encoded_string}` was decoded as " \
                   "`#{decoded}` but could not be parsed"
           end
-          new(id: decoded, order_field: :id)
+          new(primary_key_value: decoded,
+              order_field: order_field,
+              primary_key: primary_key)
         else
           unless decoded.is_a?(Array) && decoded.size == 2
             raise InvalidCursorError,
                   "The given cursor `#{encoded_string}` was decoded as " \
                   "`#{decoded}` but could not be parsed"
           end
-          new(id: decoded[1], order_field: order_field,
-              order_field_value: decoded[0])
+          new(primary_key_value: decoded[1], order_field: order_field,
+              order_field_value: decoded[0], primary_key: primary_key)
         end
       rescue ArgumentError, JSON::ParserError
         raise InvalidCursorError,
@@ -60,16 +67,25 @@ module RailsCursorPagination
 
     # Initializes the record
     #
-    # @param id [Integer]
-    #   The ID of the cursor record
+    # @param primary_key_value [Object]
+    #   The identifier of the cursor record
     # @param order_field [Symbol]
     #   The column or virtual column for ordering
     # @param order_field_value [Object]
     #   Optional. The value that the +order_field+ of the record contains in
     #   case that the order field is not the ID
-    def initialize(id:, order_field: :id, order_field_value: nil)
-      @id = id
-      @order_field = order_field
+    # @param primary_key [Symbol, String]
+    #   Column or virtual column of the record to be used instead of `id` as
+    #   primary key
+    def initialize(
+      primary_key_value:,
+      order_field: nil,
+      order_field_value: nil,
+      primary_key: :id
+    )
+      @primary_key = primary_key
+      @primary_key_value = primary_key_value
+      @order_field = order_field || primary_key
       @order_field_value = order_field_value
 
       return if !custom_order_field? || !order_field_value.nil?
@@ -82,29 +98,46 @@ module RailsCursorPagination
     # Generate an encoded string for this cursor. The cursor encodes all the
     # data required to then paginate based on it with the given ordering field.
     #
-    # If we only order by ID, the cursor doesn't need to include any other data.
+    # If we only order by primary key, the cursor doesn't need to include any
+    # other data.
     # But if we order by any other field, the cursor needs to include both the
-    # value from this other field as well as the records ID to resolve the order
-    # of duplicates in the non-ID field.
+    # value from this other field as well as the record's primary key to resolve
+    # the order of duplicates in the non-primary-key field.
     #
     # @return [String]
     def encode
       unencoded_cursor =
         if custom_order_field?
-          [@order_field_value, @id]
+          [@order_field_value, @primary_key_value]
         else
-          @id
+          @primary_key_value
         end
       Base64.strict_encode64(unencoded_cursor.to_json)
     end
 
+    # Returns the primary key value if the primary key is `id`. This should
+    # cover most cases.
+    #
+    # @deprecated Use `#primary_key_value` instead
+    # @raise [RailsCursorPagination::ParameterError]
+    #   Will raise an error if a custom primary key is set.
+    # @return [Object]
+    def id
+      unless @primary_key == :id
+        raise RailsCursorPagination::ParameterError,
+              'When using custom primary keys, the #id method is not supported'
+      end
+
+      primary_key_value
+    end
+
     private
 
-    # Returns true when the order has been overridden from the default (ID)
+    # Returns true when the order uses a column that is not the primary key.
     #
     # @return [Boolean]
     def custom_order_field?
-      @order_field != :id
+      @order_field != @primary_key
     end
   end
 end


### PR DESCRIPTION
Add a new optional parameter to the paginator to customize the primary key field to use for a query. This defaults to `:id` if unset and also affects ordering.

Setting a custom `primary_key` allows users to avoid always requesting the `id` column in the query to compute the cursor. It is up to the user to guarantee that the primary key is unique as this will affect ordering as well.

The intended use case is for when paginating records that don't have an `id` field or when paginating queries containing aggregations that are not based on an `id` field.
