### PR TITLE
Add support for table name in order by and Sorting by columns from joined table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,13 @@ These are the latest changes on the project's `master` branch that have not yet 
   Follow the same format as previous releases by categorizing your feature into "Added", "Changed", "Deprecated", "Removed", "Fixed", or "Security".
 --->
 
+### Added
+- Added support for sorting by columns from joined tables. The `order_by` parameter now accepts fully qualified column names, allowing pagination to work seamlessly with joined table columns.
+
+### Fixed
+- Ensure `order_by` columns are properly prefixed with the table name to avoid SQL ambiguity errors when joining multiple tables with columns of the same name (e.g., `created_at`).
+- Fixed cursor decoding and encoding to handle fully qualified column names (e.g., `table.column`) correctly.
+
 ## [0.4.0] - 2023-10-06
 
 ### Changed

--- a/lib/rails_cursor_pagination/paginator.rb
+++ b/lib/rails_cursor_pagination/paginator.rb
@@ -356,7 +356,7 @@ module RailsCursorPagination
     # Extract the column name from "table.column" if necessary
     #
     # @return [Symbol]
-    def order_column_name
+    def order_field_name
       @order_field.to_s.split('.').last.to_sym
     end
 
@@ -372,7 +372,7 @@ module RailsCursorPagination
     # @param record [ActiveRecord] Model instance for which we want the cursor
     # @return [String]
     def cursor_for_record(record)
-      cursor_class.from_record(record: record, order_field: order_column_name).encode
+      cursor_class.from_record(record: record, order_field: order_field_name).encode
     end
 
     # Decode the provided cursor. Either just returns the cursor's ID or in case
@@ -382,7 +382,7 @@ module RailsCursorPagination
     # @return [Integer, Array]
     def decoded_cursor
       memoize(:decoded_cursor) do
-        cursor_class.decode(encoded_string: @cursor, order_field: order_column_name)
+        cursor_class.decode(encoded_string: @cursor, order_field: order_field_name)
       end
     end
 
@@ -420,7 +420,7 @@ module RailsCursorPagination
       end
 
       if custom_order_field? && !@relation.select_values.include?(@order_field)
-        relation = relation.select("#{@order_field} AS #{order_column_name}")
+        relation = relation.select("#{@order_field} AS #{order_field_name}")
       end
 
       relation

--- a/lib/rails_cursor_pagination/paginator.rb
+++ b/lib/rails_cursor_pagination/paginator.rb
@@ -445,6 +445,19 @@ module RailsCursorPagination
       "#{escaped_table_name}.#{escaped_id_column}".freeze
     end
 
+    # Return a properly escaped reference to the order column prefixed with the
+    # table name. This prefixing is important in case of another model having
+    # been joined to the passed relation.
+    #
+    # @return [String (frozen)]
+
+    def order_column
+      escaped_table_name = @relation.quoted_table_name
+      escaped_order_column = @relation.connection.quote_column_name(@order_field)
+
+      "#{escaped_table_name}.#{escaped_order_column}".freeze
+    end
+
     # Applies the filtering based on the provided cursor and order column to the
     # sorted relation.
     #
@@ -472,11 +485,11 @@ module RailsCursorPagination
         end
 
         sorted_relation
-          .where("#{@order_field} #{filter_operator} ?",
+          .where("#{order_column} #{filter_operator} ?",
                  decoded_cursor.order_field_value)
           .or(
             sorted_relation
-              .where("#{@order_field} = ?", decoded_cursor.order_field_value)
+              .where("#{order_column} = ?", decoded_cursor.order_field_value)
               .where("#{id_column} #{filter_operator} ?", decoded_cursor.id)
           )
       end

--- a/lib/rails_cursor_pagination/paginator.rb
+++ b/lib/rails_cursor_pagination/paginator.rb
@@ -412,17 +412,17 @@ module RailsCursorPagination
     def relation_with_cursor_fields
       return @relation if @relation.select_values.blank? ||
                           @relation.select_values.include?('*')
-    
+
       relation = @relation
-    
+
       unless @relation.select_values.include?(:id)
         relation = relation.select(:id)
       end
-    
+
       if custom_order_field? && !@relation.select_values.include?(@order_field)
         relation = relation.select("#{@order_field} AS #{order_column_name}")
       end
-    
+
       relation
     end
 


### PR DESCRIPTION
This pull request addresses an issue where using the `order_by` parameter with columns that exist in multiple joined tables (e.g., `created_at`) would result in SQL ambiguity errors. The fix ensures that all `order_by` columns are properly prefixed with their respective table names, avoiding conflicts and ensuring correct query execution.

It also adds support sorting by columns from joined tables. Previously, attempting to sort by a column from a joined table would result in SQL errors or missing cursor values. With this update, the `order_by` parameter now accepts fully qualified column names (e.g., `table.column`), and the gem ensures proper handling of such cases.

**Changes Made**

- Added an `order_column` method to prefix `order_by` columns with the table name.
- Updated the `filtered_and_sorted_relation` method in `paginator.rb` to use `order_column` instead of `@order_field`.
- Queries with ambiguous order_by columns (e.g., created_at) execute without errors.
- Added support for fully qualified column names in the `order_by` parameter.
- Updated the `decoded_cursor` and `cursor_for_record` methods to correctly handle and process fully qualified column names.


**Why This Change is Necessary**

When joining multiple tables in a query, columns with the same name (e.g., created_at) become ambiguous unless explicitly prefixed with their table name. Without this fix, the gem would raise a PG::AmbiguousColumn error.
Also, Sorting by columns from joined tables is a common use case in complex queries. Without this fix, the gem would raise errors like PG::UndefinedColumn or RailsCursorPagination::ParameterError when attempting to sort by such columns. 

**Related Issues**
Resolves https://github.com/xing/rails_cursor_pagination/issues/106

_This update is backward-compatible and does not introduce breaking changes. It ensures that the gem can handle more complex queries involving joined tables._